### PR TITLE
Fix default assignment and constructor for non trivial types

### DIFF
--- a/include/experimental/fixed_capacity_vector
+++ b/include/experimental/fixed_capacity_vector
@@ -731,11 +731,11 @@ namespace std
                     }
 
                     constexpr non_trivial()                   = default;
-                    constexpr non_trivial(non_trivial const&) = default;
+                    constexpr non_trivial(non_trivial const&) = delete;
                     constexpr non_trivial& operator=(non_trivial const&)
-                        = default;
-                    constexpr non_trivial(non_trivial&&) = default;
-                    constexpr non_trivial& operator=(non_trivial&&) = default;
+                        = delete;
+                    constexpr non_trivial(non_trivial&&) = delete;
+                    constexpr non_trivial& operator=(non_trivial&&) = delete;
                     ~non_trivial() noexcept(is_nothrow_destructible_v<T>)
                     {
                         unsafe_destroy_all();
@@ -1297,7 +1297,7 @@ namespace std
             }
 
             /// Move assignment.
-            FCV_REQUIRES(fcv_detail::Assignable<reference, reference>)
+            FCV_REQUIRES(fcv_detail::MoveConstructible<value_type>)
             constexpr fixed_capacity_vector&
             operator=(fixed_capacity_vector&& other) noexcept(
                 noexcept(clear())


### PR DESCRIPTION
Storage for non trivial type would still generate default copy/move constructors. Vector class would then generate default ones even in case explicitly defined constructors were not allowed via type traits. Default constructor is preferred over templated constructor. Deleting non trivial storage constructors prevents them from being generated for vector class and forcing compiler to pick available template constructors secured with type traits.
Also, move assignment operator should depend on move-constructability, otherwise it would not be instantiated for non-copyable types.